### PR TITLE
Fix some placeholders showing incorrect data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.extendedclip.papi.expansion.mcstatistics</groupId>
     <artifactId>statistics-expansion</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <name>PAPI-Expansion-Statistic</name>
     <description>PlaceholderAPI expansion for minecraft statistic placeholders</description>
 

--- a/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ListMultimap;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.Cacheable;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import me.clip.placeholderapi.util.TimeUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -100,7 +101,7 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
              * Time played
              */
             case "time_played": {
-                return StatisticsUtils.formatTime(Duration.of(secondsPlayed, ChronoUnit.SECONDS));
+                return TimeUtil.getTime(Duration.of(secondsPlayed, ChronoUnit.SECONDS));
             }
 
             case "time_played:seconds": {
@@ -139,7 +140,7 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
              * Time since last death
              */
             case "time_since_death": {
-                return StatisticsUtils.formatTime(Duration.of(secondsSinceLastDeath, ChronoUnit.SECONDS));
+                return TimeUtil.getTime(Duration.of(secondsSinceLastDeath, ChronoUnit.SECONDS));
             }
 
             case "seconds_since_death": {

--- a/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
@@ -279,7 +279,7 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
                 continue;
             }
 
-            if (!isLegacy && material.name().startsWith("LEGACY")) {
+            if (!isLegacy && material.name().startsWith("LEGACY") || material.name().equals("BURNING_FURNACE")) {
                 continue;
             }
 

--- a/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ListMultimap;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.Cacheable;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import me.clip.placeholderapi.util.TimeUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -35,8 +34,6 @@ import org.bukkit.Statistic;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -48,7 +45,7 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
     private final String VERSION = getClass().getPackage().getImplementationVersion();
     private final boolean isLegacy = !Enums.getIfPresent(Material.class, "TURTLE_HELMET").isPresent();
     public static final String SERVER_VERSION = Bukkit.getBukkitVersion().split("-")[0];
-    
+
     @Override
     public String getAuthor() {
         return "clip";
@@ -101,7 +98,7 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
              * Time played
              */
             case "time_played": {
-                return TimeUtil.getTime(Duration.of(secondsPlayed, ChronoUnit.SECONDS));
+                return StatisticsUtils.formatTime(secondsPlayed);
             }
 
             case "time_played:seconds": {
@@ -140,7 +137,7 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
              * Time since last death
              */
             case "time_since_death": {
-                return TimeUtil.getTime(Duration.of(secondsSinceLastDeath, ChronoUnit.SECONDS));
+                return StatisticsUtils.formatTime(secondsSinceLastDeath);
             }
 
             case "seconds_since_death": {

--- a/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsExpansion.java
@@ -279,6 +279,10 @@ public class StatisticsExpansion extends PlaceholderExpansion implements Cacheab
                 continue;
             }
 
+            if (!isLegacy && material.name().startsWith("LEGACY")) {
+                continue;
+            }
+
             if (statistic == Statistic.MINE_BLOCK && (material.name().equals("GRASS") || material.name().equals("SOIL"))) {
                 continue;
             }

--- a/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsUtils.java
@@ -22,12 +22,9 @@ package com.extendedclip.papi.expansion.mcstatistics;
 
 import com.google.common.base.Enums;
 import com.google.common.base.Optional;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
-
-import java.time.Duration;
 
 public class StatisticsUtils {
     public static int getSecondsPlayed(final Player player, final boolean isLegacy) {
@@ -115,52 +112,5 @@ public class StatisticsUtils {
         } else {
             return material.isItem();
         }
-    }
-
-    /**
-     * @author Sxtanna
-     */
-    public static String formatTime(final Duration duration) {
-        final StringBuilder builder = new StringBuilder();
-
-        long seconds = duration.getSeconds();
-        long minutes = seconds / 60;
-        long hours = minutes / 60;
-        long days = hours / 24;
-
-        seconds %= 60;
-        minutes %= 60;
-        hours %= 60;
-        days %= 24;
-
-        if (seconds > 0) {
-            builder.insert(0, seconds + "s");
-        }
-
-        if (minutes > 0) {
-            if (builder.length() > 0) {
-                builder.insert(0, ' ');
-            }
-
-            builder.insert(0, minutes + "m");
-        }
-
-        if (hours > 0) {
-            if (builder.length() > 0) {
-                builder.insert(0, ' ');
-            }
-
-            builder.insert(0, hours + "h");
-        }
-
-        if (days > 0) {
-            if (builder.length() > 0) {
-                builder.insert(0, ' ');
-            }
-
-            builder.insert(0, days + "d");
-        }
-
-        return builder.toString();
     }
 }

--- a/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/mcstatistics/StatisticsUtils.java
@@ -26,6 +26,8 @@ import org.bukkit.Material;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
 
+import java.util.StringJoiner;
+
 public class StatisticsUtils {
     public static int getSecondsPlayed(final Player player, final boolean isLegacy) {
         return isLegacy ? player.getStatistic(Statistic.valueOf("PLAY_ONE_TICK")) / 20 : player.getStatistic(Statistic.PLAY_ONE_MINUTE) / 20;
@@ -112,5 +114,35 @@ public class StatisticsUtils {
         } else {
             return material.isItem();
         }
+    }
+
+    public static String formatTime(long seconds) {
+        final StringJoiner joiner = new StringJoiner(" ");
+
+        long minutes = seconds / 60;
+        long hours = minutes / 60;
+        final long days = hours / 24;
+
+        seconds %= 60;
+        minutes %= 60;
+        hours %= 24;
+
+        if (days > 0) {
+            joiner.add(days + "d");
+        }
+
+        if (hours > 0) {
+            joiner.add(hours + "h");
+        }
+
+        if (minutes > 0) {
+            joiner.add(minutes + "m");
+        }
+
+        if (seconds > 0) {
+            joiner.add(seconds + "s");
+        }
+
+        return joiner.toString();
     }
 }


### PR DESCRIPTION
If you would like to test this you can download it [here](https://github.com/DeathRealms/Statistics-Expansion/releases/tag/v2.0.1)

Fixes:
- %statistic_time_played% and %statistic_time_since_death% showing incorrect formatted time.
![changes](https://user-images.githubusercontent.com/34928126/90055868-0683ad80-dcac-11ea-8d68-26371641f396.png)

- Placeholders using the `StatisticsExpansion#calculateTotal` method showing incorrect totals